### PR TITLE
Allow disabling logs by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Woodrow Douglass](https://github.com/wdouglass) - *Test coverage*
 * [Michiel De Backker](https://github.com/backkem) - *Docs*
 * [Hugo Arregui](https://github.com/hugoArregui) - *Custom Logs*
+* [Justin Okamoto](https://github.com/justinokamoto) - *Disabled Logs Update*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/logger.go
+++ b/logger.go
@@ -181,15 +181,21 @@ func NewDefaultLoggerFactory() *DefaultLoggerFactory {
 	factory.Writer = os.Stdout
 
 	logLevels := map[string]LogLevel{
-		"ERROR": LogLevelError,
-		"WARN":  LogLevelWarn,
-		"INFO":  LogLevelInfo,
-		"DEBUG": LogLevelDebug,
-		"TRACE": LogLevelTrace,
+		"DISABLE": LogLevelDisabled,
+		"ERROR":   LogLevelError,
+		"WARN":    LogLevelWarn,
+		"INFO":    LogLevelInfo,
+		"DEBUG":   LogLevelDebug,
+		"TRACE":   LogLevelTrace,
 	}
 
 	for name, level := range logLevels {
-		env := os.Getenv(fmt.Sprintf("PIONS_LOG_%s", name))
+		env := os.Getenv(fmt.Sprintf("PION_LOG_%s", name))
+
+		if env == "" {
+			env = os.Getenv(fmt.Sprintf("PIONS_LOG_%s", name))
+		}
+
 		if env == "" {
 			continue
 		}


### PR DESCRIPTION
#### Description

Allows users to disable logs without having to use webrtc.API
to configure custom logger factory. Also updates naming
'PIONS' -> 'PION'.

#### Reference issue

Fixes #7 
