### PR TITLE
Update golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - GO111MODULE=on
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.15.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
 
 script:
   - golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Michiel De Backker](https://github.com/backkem) - *Docs*
 * [Hugo Arregui](https://github.com/hugoArregui) - *Custom Logs*
 * [Justin Okamoto](https://github.com/justinokamoto) - *Disabled Logs Update*
+* [Atsushi Watanabe](https://github.com/at-wat) - *Fix/update CI*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
`typecheck` detects false-positive errors in Go1.13 stdlib.

ref: https://github.com/pion/logging/pull/13#issuecomment-571844043