### PR TITLE
Log to stderr by default, not stdout

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -156,7 +156,7 @@ func (ll *DefaultLeveledLogger) Errorf(format string, args ...interface{}) {
 // NewDefaultLeveledLoggerForScope returns a configured LeveledLogger
 func NewDefaultLeveledLoggerForScope(scope string, level LogLevel, writer io.Writer) *DefaultLeveledLogger {
 	if writer == nil {
-		writer = os.Stdout
+		writer = os.Stderr
 	}
 	logger := &DefaultLeveledLogger{
 		writer: &loggerWriter{output: writer},
@@ -182,7 +182,7 @@ func NewDefaultLoggerFactory() *DefaultLoggerFactory {
 	factory := DefaultLoggerFactory{}
 	factory.DefaultLogLevel = LogLevelError
 	factory.ScopeLevels = make(map[string]LogLevel)
-	factory.Writer = os.Stdout
+	factory.Writer = os.Stderr
 
 	logLevels := map[string]LogLevel{
 		"DISABLE": LogLevelDisabled,

--- a/logging_test.go
+++ b/logging_test.go
@@ -73,7 +73,7 @@ func testErrorLevel(t *testing.T, logger *logging.DefaultLeveledLogger) {
 
 func TestDefaultLoggerFactory(t *testing.T) {
 	f := logging.DefaultLoggerFactory{
-		Writer:          os.Stdout,
+		Writer:          os.Stderr,
 		DefaultLogLevel: logging.LogLevelWarn,
 		ScopeLevels: map[string]logging.LogLevel{
 			"foo": logging.LogLevelDebug,
@@ -100,7 +100,7 @@ func TestDefaultLoggerFactory(t *testing.T) {
 
 func TestDefaultLogger(t *testing.T) {
 	logger := logging.
-		NewDefaultLeveledLoggerForScope("test1", logging.LogLevelWarn, os.Stdout)
+		NewDefaultLeveledLoggerForScope("test1", logging.LogLevelWarn, os.Stderr)
 
 	testNoDebugLevel(t, logger)
 	testWarnLevel(t, logger)
@@ -109,7 +109,7 @@ func TestDefaultLogger(t *testing.T) {
 
 func TestSetLevel(t *testing.T) {
 	logger := logging.
-		NewDefaultLeveledLoggerForScope("testSetLevel", logging.LogLevelWarn, os.Stdout)
+		NewDefaultLeveledLoggerForScope("testSetLevel", logging.LogLevelWarn, os.Stderr)
 
 	testNoDebugLevel(t, logger)
 	logger.SetLevel(logging.LogLevelDebug)


### PR DESCRIPTION
Go's log package writes to stderr by default (like all/most loggers). However pion's logger by default writes to stdout by default, even though pion's packages that use the logger mostly (but not always) override this to stderr. So projects using both will end up with a mix of log messages to stdout and stderr, which isn't desirable when trying to separate out the log output. This PR changes the default logging fd to stderr, and also changes the logger test to be consistent with pion's usage in writing to stderr.